### PR TITLE
chore(deps): bump github.com/sourcekris/goflint from v1.0.1 to v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/jbarham/primegen v0.0.0-20200302115600-8ce4838491a0
 	github.com/kavehmz/prime v1.0.0
-	github.com/sourcekris/goflint v1.0.1
+	github.com/sourcekris/goflint v1.0.2
 	github.com/sourcekris/gogmpecm v0.0.0-20211214113902-8a5f196d84bc
 	github.com/sourcekris/mathparse v0.0.0-20211122043138-232758c46ee7
 	github.com/sourcekris/x509big v0.0.0-20211122043228-e8ea46e23d32

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/jbarham/primegen v0.0.0-20200302115600-8ce4838491a0/go.mod h1:Airb7uq
 github.com/kavehmz/prime v1.0.0 h1:7nwQQWxmw/DYw5/fQdphqkmgWmoln6zcvYav1v29Bo0=
 github.com/kavehmz/prime v1.0.0/go.mod h1:o8keQ+3ZXNoHQHNjdjnACFJUNhN0RfHyGvkzQzbzl78=
 github.com/sourcekris/goflint v0.0.0-20210914114802-f9662cf830a9/go.mod h1:6J49YTQ8HphjsifNRSe1bSNVCE29zlu5W9bGd+1PdxU=
-github.com/sourcekris/goflint v1.0.1 h1:qq0DZyEZrQ8YRzxKGXretEEWXb+m80sbEtBl/8QR9Ik=
-github.com/sourcekris/goflint v1.0.1/go.mod h1:0ZUDLmp6m/l4oMsXITQYD6gM1mivhulLBc6eAEiVs+E=
+github.com/sourcekris/goflint v1.0.2 h1:YYzttKz7yyPRXf63mGosJIq6c0Ll2SWLIz+9sJCSCcU=
+github.com/sourcekris/goflint v1.0.2/go.mod h1:0ZUDLmp6m/l4oMsXITQYD6gM1mivhulLBc6eAEiVs+E=
 github.com/sourcekris/gogmpecm v0.0.0-20211214113902-8a5f196d84bc h1:ZOmgsxlLvnd6cSgW//Q7oBmHZ1j+SCX8ziHOuBGm/Ro=
 github.com/sourcekris/gogmpecm v0.0.0-20211214113902-8a5f196d84bc/go.mod h1:tXu70utapcitOP5k9+RhQOkWC4dYlu9tWpYK8Pf8pek=
 github.com/sourcekris/mathparse v0.0.0-20211122043138-232758c46ee7 h1:2sjppih/GmHB1M7PUWhHRtk3wHC8quS8iUO/i4UKJ+o=


### PR DESCRIPTION
## Summary
Bumps `github.com/sourcekris/goflint` from `v1.0.1` to `v1.0.2`.

## Changes
- Updated `goflint` dependency to `v1.0.2` in `go.mod`
- Regenerated `go.sum` to reflect the updated version

## Motivation
Keep dependencies up to date with the latest fixes and improvements.

## Testing
- `go mod tidy`

## Checklist
- [x] Dependencies updated
- [x] `go mod tidy` run